### PR TITLE
Relocate 'search' role attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog:
 
 - - -
+## 0.1.2 - 2017-08-08
+
+#### Fixed:
+* Relocated 'search' role attribute
+- - -
 ## 0.1.1 - 2017-06-15
 
 #### New features:

--- a/mkdocs_docskimmer/search.html
+++ b/mkdocs_docskimmer/search.html
@@ -11,8 +11,8 @@
 {% endblock styles %}
 
 {% block search %}
-  <form class="form form--search" id="content_search" action="search.html" role="search">
-    <div class="form-group">
+  <form class="form form--search" id="content_search" action="search.html">
+    <div class="form-group" role="search">
       <label class="hidden" for="mkdocs-search-query">Search for:</label>
       <input type="search" aria-label="Search" class="form__input" name="q" id="mkdocs-search-query" tabindex="3"> <button type="submit" class="form__btn-submit">Search</button>
     </div>

--- a/mkdocs_docskimmer/searchbox.html
+++ b/mkdocs_docskimmer/searchbox.html
@@ -1,6 +1,6 @@
 {% block search %}
-  <form class="form form--search" id="content_search" action="{{ base_url }}/search.html" method="get" role="search">
-    <div class="form-group">
+  <form class="form form--search" id="content_search" action="{{ base_url }}/search.html" method="get">
+    <div class="form-group"  role="search">
       <label class="hidden" for="mkdocs-search-query">Search for:</label>
       <input type="search" aria-label="Search" class="form__input" name="q" id="mkdocs-search-query" placeholder="Search the docs for..." tabindex="3"> <button type="submit" class="form__btn-submit">Search</button>
     </div>


### PR DESCRIPTION
Form element already has implicit (more generic) `role='form'`.
`role="search"` is relocated to a nested (wrapper) element.