### PR TITLE
New release: v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog:
 
 - - -
+## 0.2.1 - 2017-06-27
+
+#### New features:
+* Compatible with [MkDocs versions >= 0.17.0 (ie. v0.17.0, v0.17.2, v0.17.3, v0.17.4)](https://github.com/mkdocs/mkdocs/releases)
+
+#### Changed:
+* Updated [demo](https://hfagerlund.github.io/mkdocs-docskimmer/) (to docSkimmer v0.2.1)
+* Bumped version number
+
+#### Fixed:
+* Improved configuration for compatibility with multiple 0.17.x versions
+* Fixed typos in demo and README links (to 'Version compatibility' section)
+- - -
 ## 0.2.0 - 2017-06-26
 
 #### New features:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ Or [download the required version](https://github.com/hfagerlund/mkdocs-docskimm
 
 * Copy the contents of the `mkdocs_docskimmer` directory into the MkDocs project root (ie. at the same level as the `docs` directory).
 
+### For docSkimmer v0.2.1:
+
+* Add to `mkdocs.yml`:
+
+```
+theme:
+  name: null
+  custom_dir: 'mkdocs_docskimmer'
+  include_search_page: true
+  search_index_only: false
+  static_templates:
+  - 404.html
+
+plugins: ['search']
+
+extra:
+    version: 0.2.1
+
+```
+
 ### For docSkimmer v0.2.0:
 
 * Add to `mkdocs.yml`:
@@ -60,8 +80,9 @@ theme_dir: 'mkdocs_docskimmer'
 
 | docSkimmer theme version(s) | MkDocs version(s) |
 | :------: | :------: |
+| 0.2.1 | 0.17.4<br>0.17.3<br>0.17.2<br>0.17.0 |
 | 0.2.0 | 0.17.0 |
-| 0.1.0<br>0.1.1 | 0.16.2<br>0.16.3 |
+| 0.1.1<br>0.1.0 | 0.16.3<br>0.16.2 |
 
 ## Demo
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="../css/docskimmer.css" type="text/css">
 
   
-  
+
 
     <link rel="shortcut icon" href="/mkdocs-docskimmer/img/favicon.ico">
 	  <link rel="apple-touch-icon" href="/mkdocs-docskimmer/img/apple-touch-icon.png">
@@ -132,15 +132,16 @@
   <script src="../js/theme.js"></script>
   <script src="../search/text.js"></script>
   <script src="../search/lunr.min.js"></script>
+
   
-	<script src="/mkdocs-docskimmer/search/require.js"></script>
-	<script src="/mkdocs-docskimmer/search/search.js"></script>
+    <script src="/mkdocs-docskimmer/search/require.js"></script>
+    <script src="/mkdocs-docskimmer/search/search.js"></script>
 
 
   <!--
-  MkDocs version : 0.17.0
-  docSkimmer theme version: 0.2.0
-  Build Date UTC : 2018-06-26 20:26:38
+  MkDocs version : 0.17.4
+  docSkimmer theme version: 0.2.1
+  Build Date UTC : 2018-06-27 17:21:30
   -->
   </body>
 </html>

--- a/docs/css/docskimmer.css
+++ b/docs/css/docskimmer.css
@@ -1,5 +1,5 @@
 /*
-   docSkimmer theme v0.2.0
+   docSkimmer theme v0.2.1
    License: BSD-2-Clause license (https://github.com/hfagerlund/mkdocs-docskimmer/blob/master/LICENSE)
 */
 

--- a/docs/examples/another-sample-page/index.html
+++ b/docs/examples/another-sample-page/index.html
@@ -530,9 +530,9 @@ sit amet laoreet nibh.</p>
   
 
   <!--
-  MkDocs version : 0.17.0
-  docSkimmer theme version: 0.2.0
-  Build Date UTC : 2018-06-26 20:26:39
+  MkDocs version : 0.17.4
+  docSkimmer theme version: 0.2.1
+  Build Date UTC : 2018-06-27 17:21:30
   -->
   </body>
 </html>

--- a/docs/examples/sample-page/index.html
+++ b/docs/examples/sample-page/index.html
@@ -532,9 +532,9 @@ sit amet laoreet nibh.</p>
   
 
   <!--
-  MkDocs version : 0.17.0
-  docSkimmer theme version: 0.2.0
-  Build Date UTC : 2018-06-26 20:26:39
+  MkDocs version : 0.17.4
+  docSkimmer theme version: 0.2.1
+  Build Date UTC : 2018-06-27 17:21:30
   -->
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -113,10 +113,29 @@
 <pre><code>git clone https://github.com/hfagerlund/mkdocs-docskimmer.git
 </code></pre>
 
-<p>Or <a href="https://github.com/hfagerlund/mkdocs-docskimmer/releases">download the required version</a> - refer to: <a href="https://hfagerlund.github.io/mkdocs-docskimmer/#version">'Version compatibility'</a>.</p>
+<p>Or <a href="https://github.com/hfagerlund/mkdocs-docskimmer/releases">download the required version</a> - refer to: <a href="https://hfagerlund.github.io/mkdocs-docskimmer/#version-compatibility">'Version compatibility'</a>.</p>
 <ul>
 <li>Copy the contents of the '/mkdocs_docskimmer' directory into your MkDocs project root (ie. at the same level as the project's '/docs' directory).</li>
 </ul>
+<h3 id="for-docskimmer-v021">For docSkimmer v0.2.1:</h3>
+<ul>
+<li>Add the following to 'mkdocs.yml' -</li>
+</ul>
+<pre><code>theme:
+  name: null
+  custom_dir: 'mkdocs_docskimmer'
+  include_search_page: true
+  search_index_only: false
+  static_templates:
+  - 404.html
+
+plugins: ['search']
+
+extra:
+    version: 0.2.1
+
+</code></pre>
+
 <h3 id="for-docskimmer-v020">For docSkimmer v0.2.0:</h3>
 <ul>
 <li>Add the following to 'mkdocs.yml' -</li>
@@ -150,12 +169,16 @@ extra:
 </thead>
 <tbody>
 <tr>
+<td align="center">0.2.1</td>
+<td align="center">0.17.4<br>0.17.3<br>0.17.2<br>0.17.0</td>
+</tr>
+<tr>
 <td align="center">0.2.0</td>
 <td align="center">0.17.0</td>
 </tr>
 <tr>
-<td align="center">0.1.0<br>0.1.1</td>
-<td align="center">0.16.2<br>0.16.3</td>
+<td align="center">0.1.1<br>0.1.0</td>
+<td align="center">0.16.3<br>0.16.2</td>
 </tr>
 </tbody>
 </table>
@@ -224,9 +247,9 @@ extra:
   
 
   <!--
-  MkDocs version : 0.17.0
-  docSkimmer theme version: 0.2.0
-  Build Date UTC : 2018-06-26 20:26:39
+  MkDocs version : 0.17.4
+  docSkimmer theme version: 0.2.1
+  Build Date UTC : 2018-06-27 17:21:30
   -->
   </body>
 </html>

--- a/docs/js/theme.js
+++ b/docs/js/theme.js
@@ -1,5 +1,5 @@
 /*
-   docSkimmer theme v0.2.0
+   docSkimmer theme v0.2.1
    License: BSD-2-Clause license (https://github.com/hfagerlund/mkdocs-docskimmer/blob/master/LICENSE)
 */
 
@@ -37,7 +37,7 @@ var MenuPanel = (function() {
     if((event.keyCode === 13 || event.keyCode === 32) || (event.type === 'click')){
       containerPageToc.style.width = "0";
       containerMainContent.style.marginLeft= "2em";
-      //check whether page-toc link was activated 
+      //check whether page-toc link was activated
       if(event.target.href){
         var link = event.target.href,
             anchor = "#";
@@ -48,11 +48,11 @@ var MenuPanel = (function() {
       }
     }
   }
-  
+
   return {
     init: function() {
       if(containerPageToc){
-      	_bindEventListeners();
+        _bindEventListeners();
       } else {
         _hideMenuOpenControl();
       }

--- a/docs/search.html
+++ b/docs/search.html
@@ -141,9 +141,9 @@
   
 
   <!--
-  MkDocs version : 0.17.0
-  docSkimmer theme version: 0.2.0
-  Build Date UTC : 2018-06-26 20:26:38
+  MkDocs version : 0.17.4
+  docSkimmer theme version: 0.2.1
+  Build Date UTC : 2018-06-27 17:21:30
   -->
   </body>
 </html>

--- a/docs/search/search_index.json
+++ b/docs/search/search_index.json
@@ -2,7 +2,7 @@
     "docs": [
         {
             "location": "/", 
-            "text": "docSkimmer\n\n\ndocSkimmer\n is a skimmable minimal theme for static documentation sites built using \nMkDocs\n.\n\n\nFeatures\n\n\n\n\naccessible;\n\n\nlightweight - no fonts or libs included (except for a single ~2KB module) - so that you can add only what you prefer;\n\n\nresponsive;\n\n\nskimmable;\n\n\nvalid HTML5 + CSS3.\n\n\n\n\nInstallation\n\n\n\n\nClone \ndocSkimmer from GitHub\n:\n\n\n\n\ngit clone https://github.com/hfagerlund/mkdocs-docskimmer.git\n\n\n\n\nOr \ndownload the required version\n - refer to: \n'Version compatibility'\n.\n\n\n\n\nCopy the contents of the '/mkdocs_docskimmer' directory into your MkDocs project root (ie. at the same level as the project's '/docs' directory).\n\n\n\n\nFor docSkimmer v0.2.0:\n\n\n\n\nAdd the following to 'mkdocs.yml' -\n\n\n\n\ntheme:\n    name: null\n    custom_dir: 'mkdocs_docskimmer'\n\nstatic_templates:\n    - 404.html\n\nextra:\n    version: 0.2.0\n\n\n\n\n\nFor docSkimmer v0.1.x:\n\n\n\n\nAdd the following to 'mkdocs.yml' -\n\n\n\n\ntheme_dir: 'mkdocs_docskimmer'\n\n\n\n\nVersion compatibility\n\n\n\n\n\n\n\n\ndocSkimmer theme version(s)\n\n\nMkDocs version(s)\n\n\n\n\n\n\n\n\n\n\n0.2.0\n\n\n0.17.0\n\n\n\n\n\n\n0.1.0\n0.1.1\n\n\n0.16.2\n0.16.3\n\n\n\n\n\n\n\n\nExamples\n\n\nExamples of how Markdown syntax is rendered and how 2nd-level navigation is displayed in the \ndocSkimmer theme\n are available on \nthis sample page\n.", 
+            "text": "docSkimmer\n\n\ndocSkimmer\n is a skimmable minimal theme for static documentation sites built using \nMkDocs\n.\n\n\nFeatures\n\n\n\n\naccessible;\n\n\nlightweight - no fonts or libs included (except for a single ~2KB module) - so that you can add only what you prefer;\n\n\nresponsive;\n\n\nskimmable;\n\n\nvalid HTML5 + CSS3.\n\n\n\n\nInstallation\n\n\n\n\nClone \ndocSkimmer from GitHub\n:\n\n\n\n\ngit clone https://github.com/hfagerlund/mkdocs-docskimmer.git\n\n\n\n\nOr \ndownload the required version\n - refer to: \n'Version compatibility'\n.\n\n\n\n\nCopy the contents of the '/mkdocs_docskimmer' directory into your MkDocs project root (ie. at the same level as the project's '/docs' directory).\n\n\n\n\nFor docSkimmer v0.2.1:\n\n\n\n\nAdd the following to 'mkdocs.yml' -\n\n\n\n\ntheme:\n  name: null\n  custom_dir: 'mkdocs_docskimmer'\n  include_search_page: true\n  search_index_only: false\n  static_templates:\n  - 404.html\n\nplugins: ['search']\n\nextra:\n    version: 0.2.1\n\n\n\n\n\nFor docSkimmer v0.2.0:\n\n\n\n\nAdd the following to 'mkdocs.yml' -\n\n\n\n\ntheme:\n    name: null\n    custom_dir: 'mkdocs_docskimmer'\n\nstatic_templates:\n    - 404.html\n\nextra:\n    version: 0.2.0\n\n\n\n\n\nFor docSkimmer v0.1.x:\n\n\n\n\nAdd the following to 'mkdocs.yml' -\n\n\n\n\ntheme_dir: 'mkdocs_docskimmer'\n\n\n\n\nVersion compatibility\n\n\n\n\n\n\n\n\ndocSkimmer theme version(s)\n\n\nMkDocs version(s)\n\n\n\n\n\n\n\n\n\n\n0.2.1\n\n\n0.17.4\n0.17.3\n0.17.2\n0.17.0\n\n\n\n\n\n\n0.2.0\n\n\n0.17.0\n\n\n\n\n\n\n0.1.1\n0.1.0\n\n\n0.16.3\n0.16.2\n\n\n\n\n\n\n\n\nExamples\n\n\nExamples of how Markdown syntax is rendered and how 2nd-level navigation is displayed in the \ndocSkimmer theme\n are available on \nthis sample page\n.", 
             "title": "Intro"
         }, 
         {
@@ -21,6 +21,11 @@
             "title": "Installation"
         }, 
         {
+            "location": "/#for-docskimmer-v021", 
+            "text": "Add the following to 'mkdocs.yml' -   theme:\n  name: null\n  custom_dir: 'mkdocs_docskimmer'\n  include_search_page: true\n  search_index_only: false\n  static_templates:\n  - 404.html\n\nplugins: ['search']\n\nextra:\n    version: 0.2.1", 
+            "title": "For docSkimmer v0.2.1:"
+        }, 
+        {
             "location": "/#for-docskimmer-v020", 
             "text": "Add the following to 'mkdocs.yml' -   theme:\n    name: null\n    custom_dir: 'mkdocs_docskimmer'\n\nstatic_templates:\n    - 404.html\n\nextra:\n    version: 0.2.0", 
             "title": "For docSkimmer v0.2.0:"
@@ -32,7 +37,7 @@
         }, 
         {
             "location": "/#version-compatibility", 
-            "text": "docSkimmer theme version(s)  MkDocs version(s)      0.2.0  0.17.0    0.1.0 0.1.1  0.16.2 0.16.3", 
+            "text": "docSkimmer theme version(s)  MkDocs version(s)      0.2.1  0.17.4 0.17.3 0.17.2 0.17.0    0.2.0  0.17.0    0.1.1 0.1.0  0.16.3 0.16.2", 
             "title": "Version compatibility"
         }, 
         {

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,28 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-
-    
     <url>
      <loc>https://hfagerlund.github.io/mkdocs-docskimmer/</loc>
-     <lastmod>2018-06-26</lastmod>
+     <lastmod>2018-06-27</lastmod>
      <changefreq>daily</changefreq>
     </url>
-    
-
-    
-        
     <url>
      <loc>https://hfagerlund.github.io/mkdocs-docskimmer/examples/sample-page/</loc>
-     <lastmod>2018-06-26</lastmod>
+     <lastmod>2018-06-27</lastmod>
      <changefreq>daily</changefreq>
     </url>
-        
     <url>
      <loc>https://hfagerlund.github.io/mkdocs-docskimmer/examples/another-sample-page/</loc>
-     <lastmod>2018-06-26</lastmod>
+     <lastmod>2018-06-27</lastmod>
      <changefreq>daily</changefreq>
     </url>
-        
-    
-
 </urlset>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,15 +12,17 @@ pages:
         - Sample2: examples/another-sample-page.md
 
 theme:
-    name: null
-    custom_dir: 'mkdocs_docskimmer'
+  name: null
+  custom_dir: 'mkdocs_docskimmer'
+  include_search_page: true
+  search_index_only: false
+  static_templates:
+  - 404.html
 
-static_templates:
-    - 404.html
+plugins: ['search']
 
 extra:
-    version: 0.2.0
+    version: 0.2.1
 
 copyright: Copyright &copy; 2017 Heini Fagerlund
 google_analytics: ['UA-38407980-4', 'auto']
-

--- a/mkdocs_docskimmer/css/docskimmer.css
+++ b/mkdocs_docskimmer/css/docskimmer.css
@@ -1,5 +1,5 @@
 /*
-   docSkimmer theme v0.2.0
+   docSkimmer theme v0.2.1
    License: BSD-2-Clause license (https://github.com/hfagerlund/mkdocs-docskimmer/blob/master/LICENSE)
 */
 

--- a/mkdocs_docskimmer/js/theme.js
+++ b/mkdocs_docskimmer/js/theme.js
@@ -1,5 +1,5 @@
 /*
-   docSkimmer theme v0.2.0
+   docSkimmer theme v0.2.1
    License: BSD-2-Clause license (https://github.com/hfagerlund/mkdocs-docskimmer/blob/master/LICENSE)
 */
 

--- a/mkdocs_docskimmer/mkdocs_theme.yml
+++ b/mkdocs_docskimmer/mkdocs_theme.yml
@@ -1,4 +1,1 @@
 # config options for 'docSkimmer' theme
-
-static_templates:
-    - 404.html

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 
 setup(


### PR DESCRIPTION
Resolves #5 .

Note: This version of the docSkimmer theme is compatible with all of the [current MkDocs 0.17.x versions](https://github.com/mkdocs/mkdocs/releases):
* 0.17.4
* 0.17.3
* 0.17.2
* 0.17.0